### PR TITLE
Add Prod Deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,13 +19,20 @@ try {
   } else {
     core.setOutput('branch_name', branchName);
   }
-
+ 
   // Calculate should_deploy and set as output
   const deployableBranches = ['development', 'qa', 'staging', 'production', 'labs'];
   if(deployableBranches.includes(branchName)) {
     shouldDeploy = true;
   }
   core.setOutput('should_deploy', shouldDeploy);
+
+  // Check if it's Staging or Productions
+  const prodBranches = ['staging', 'production'];
+  if(prodBranches.includes(branchName)) {
+    prodDeploy = true;
+  }
+  core.setOutput('prod_deploy', prodDeploy);
 } catch (error) {
   core.setFailed(error.message);
 }

--- a/index.js
+++ b/index.js
@@ -27,12 +27,18 @@ try {
   }
   core.setOutput('should_deploy', shouldDeploy);
 
-  // Check if it's Staging or Productions
-  const prodBranches = ['staging', 'production'];
-  if(prodBranches.includes(branchName)) {
-    prodDeploy = true;
+  // Check if it's Staging or Productions or labs
+  const ProdBranches = ['staging', 'production', 'labs'];
+  if(ProdBranches.includes(branchName)) {
+    ProdDeploy = true;
   }
-  core.setOutput('prod_deploy', prodDeploy);
+  core.setOutput('prod_deploy', ProdDeploy);
+  // Check if it's Dev or QA
+  const NonProdBranches = ['development', 'qa'];
+  if(NonProdBranches.includes(branchName)) {
+    NonProdDeploy = true;
+  }
+  core.setOutput('non_prod_deploy', NonProdDeploy);
 } catch (error) {
   core.setFailed(error.message);
 }


### PR DESCRIPTION
Hi @saiumesh-apty,

Reason for this PR is we give below condition for Staging and Prod check, 
```yaml
if: needs.rules.outputs.should_deploy == 'true' && (needs.rules.outputs.branch_name == 'production' || needs.rules.outputs.branch_name == 'staging')
```
And from the above condition, actions is only taking the first part, and the second condition is omitted i.e anything after "||", due to which when it's running in staging both the jobs mac and Linux (For assist) is getting started. 
This is not happening in Dev and QA because it's just checking (needs.rules.outputs.branch_name != 'production') and since it's not production, it's running.

Below reference, 

https://github.com/aptyInc/poc-github-actions/runs/3028295276?check_suite_focus=true (In DEV)
https://github.com/aptyInc/poc-github-actions/actions/runs/1014897940 (In STG)

