### PR TITLE
Include DOT in regex.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ try {
   }
 
   // Validate and set branch Name
-  const validBranchRegex = /(^(feature|bugfix|hotfix|onprem)\/(LSP|CB|AQRE|LP|ASE)-[0-9]{1,5}\/[0-9a-zA-Z_-]+$)|(^(development|staging|production|qa|labs)$)/;
+  const validBranchRegex = /(^(feature|bugfix|hotfix|onprem)\/(LSP|CB|AQRE|LP|ASE)-[0-9]{1,6}\/[0-9a-zA-Z_-\\.]+$)|(^(development|staging|production|qa|labs)$)/;
   if (!validBranchRegex.test(branchName)) {
     core.setFailed(`Branch Name should be in the regex format ${validBranchRegex}`);
   } else {


### PR DESCRIPTION
Hi @saiumesh-apty,

Currently GHA fails if the branch name has `.` in it, hence raised this PR, Also have increased the ticket number limit from 5 to 6.

![2021-09-21_18-13](https://user-images.githubusercontent.com/83000807/134172691-482b0edf-1996-4d1e-8e16-5057352f547d.png)